### PR TITLE
bigger clocks and highlight turn with background-color, based on lichess

### DIFF
--- a/src/ChessVariantsTraining/Views/Variant960/Game.cshtml
+++ b/src/ChessVariantsTraining/Views/Variant960/Game.cshtml
@@ -101,7 +101,7 @@
         }
         <p>@Model.RenderWhiteText() @Model.RenderWhiteLink(Url)<br>@Model.RenderBlackText() @Model.RenderBlackLink(Url)</p>
         <p>@(Model.ShortVariant == "Horde" ? "White's position: standard" : "White's position: " + Model.WhitePosition)<br>Black's position: @Model.BlackPosition</p>
-        <p>White clock: <span id="white-clock"></span><br>Black clock: <span id="black-clock"></span></p>
+        <p>White clock: <span id="white-clock" class="clocks"></span><br>Black clock: <span id="black-clock" class="clocks"></span></p>
         <p>Variant: @Model.Variant</p>
         <p>Time control: @Model.TimeControl.ToString()</p>
         <p id="additional-info"></p>

--- a/src/ChessVariantsTraining/wwwroot/scripts/variant960/game.js
+++ b/src/ChessVariantsTraining/wwwroot/scripts/variant960/game.js
@@ -387,9 +387,16 @@
         clockInfo[which + "Value"] = seconds;
         updateClockElement(which);
     }
-
+    // opponent's color
+    function opponent(which) {
+        if (which == "white") 
+            return "black";
+        else return "white";
+    }
     function updateClockElement(which) {
         document.getElementById(which + "-clock").textContent = clockDisplay(clockInfo[which + "Value"]);
+        document.getElementById(opponent(which) + "-clock").className = "clocks";
+        document.getElementById(which + "-clock").className = "clocks turn";
         if (clockInfo[which + "Value"] < 20) {
             document.getElementById(which + "-clock").style.color = "red";
         } else {

--- a/src/ChessVariantsTraining/wwwroot/styles/main.css
+++ b/src/ChessVariantsTraining/wwwroot/styles/main.css
@@ -76,3 +76,16 @@ table.align-left th {
 #error-overlay-close {
     font-size: 0.5em;
 }
+
+.clocks {
+    font-size: 40px;
+    color: #4d4d4d;
+}
+
+.turn {
+    background-color: #d0e0bd;
+}
+
+.low-time {
+    background-color: indianred;
+}


### PR DESCRIPTION
Just trying this out.
Added simple CSS codes on main.css and simple code changes onto game.js to fit with the CSS.
(Not Responsive)
Added opponent's color function.
Clocks could also be arranged by the side who's playing (aka white goes down when the player is white and vice-versa ofc)
Tested locally, against myself, goes red when it's below 20 seconds.
(In the future, might add the notification sound when it beeps below 20 secs, just once like lichess does)

Still don't know how to clear the background of the clocks when the game is over.